### PR TITLE
Support for ActiveRecord 6

### DIFF
--- a/activerecord-redshift.gemspec
+++ b/activerecord-redshift.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/bricolages/activerecord-redshift'
 
   s.files = Dir.glob(['LICENSE', 'README.md'])
-  s.add_dependency 'activerecord5-redshift-adapter'
+  s.add_dependency 'activerecord6-redshift-adapter'
 end

--- a/activerecord-redshift.gemspec
+++ b/activerecord-redshift.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'activerecord-redshift'
-  s.version = '5.0.0'
+  s.version = '6.0.0'
   s.summary = 'Amazon Redshift Meta Adapter for Rails ActiveRecord'
   s.license = 'MIT'
 


### PR DESCRIPTION
Use [activerecord6-redshift-adapter](https://github.com/kwent/activerecord6-redshift-adapter) to support ActiveRecord 6

ref https://github.com/ConsultingMD/activerecord5-redshift-adapter/issues/26